### PR TITLE
fix: increase get cluster info timeout to account for delay in downloading the 4.19 content

### DIFF
--- a/ansible-bastion/playbooks/roles/monitor/tasks/agent.yaml
+++ b/ansible-bastion/playbooks/roles/monitor/tasks/agent.yaml
@@ -23,8 +23,8 @@
     status_code: 200
   register: infraenv_result
   until: infraenv_result.status == 200 and infraenv_result.json | length > 0
-  retries: 60
-  delay: 20
+  retries: 90
+  delay: 30
 
 
 - name: Show cluster infraenv ID


### PR DESCRIPTION
fix: increase get cluster info timeout to account for delay in downloading the 4.19 content

Hey @cs-zhang please review/approve/merge. Thanks, Paul