### PR TITLE
fix: add techpreviewnoupgrade and osImageStream variables that are picked up by install-config.yaml

### DIFF
--- a/ansible-bastion/playbooks/defaults/main.yaml
+++ b/ansible-bastion/playbooks/defaults/main.yaml
@@ -28,6 +28,13 @@ proxy_url: ""
 no_proxy: "127.0.0.1,{{ dhcp.subnet }},10.0.0.0/8,192.168.0.0/16"
 # set fips mode
 fips_compliant: false
+# enable tech preview features (acts as boolean, intentionally a string)
+# valid values: "true", "false", "" (empty string means disabled)
+tech_preview: ""
+# set OS image stream for RHEL-based RHCOS
+# valid values: "rhel-10", "rhel-9", "" (empty string means use default)
+# only applies when tech_preview is enabled
+os_image_stream: ""
 # storage_type could be: "" or "nfs"
 storage_type: ""
 ########################

--- a/ansible-bastion/playbooks/roles/ignition/templates/install-config.yaml.j2
+++ b/ansible-bastion/playbooks/roles/ignition/templates/install-config.yaml.j2
@@ -74,3 +74,9 @@ proxy:
   noProxy: .{{ dns.clusterid }}.{{ dns.domain }},{{ no_proxy }}
 {% endif %}
 fips: {{ fips_compliant }}
+{% if tech_preview | string | lower in ['true', 'yes', '1'] %}
+featureSet: TechPreviewNoUpgrade
+{% endif %}
+{% if os_image_stream in ['rhel-10', 'rhel-9'] %}
+osImageStream: {{ os_image_stream }}
+{% endif %}

--- a/tf-common/2_config_ocp/config_ocp.tf
+++ b/tf-common/2_config_ocp/config_ocp.tf
@@ -112,6 +112,8 @@ locals {
     release_image_override     = var.enable_local_registry ? local.local_registry_ocp_image : var.release_image_override
     enable_local_registry      = var.enable_local_registry
     fips_compliant             = var.fips_compliant
+    tech_preview               = var.tech_preview
+    os_image_stream            = var.os_image_stream
     node_connection_timeout    = 60 * var.connection_timeout
     rhcos_pre_kernel_options   = var.rhcos_pre_kernel_options
     rhcos_kernel_options       = var.rhcos_kernel_options

--- a/tf-common/2_config_ocp/templates/bastion_vars.yaml
+++ b/tf-common/2_config_ocp/templates/bastion_vars.yaml
@@ -102,6 +102,8 @@ storage_type: "${storage_type}"
 release_image_override: '${release_image_override}'
 enable_local_registry: ${enable_local_registry}
 fips_compliant: "${fips_compliant}"
+tech_preview: "${tech_preview}"
+os_image_stream: "${os_image_stream}"
 
 node_connection_timeout: ${node_connection_timeout}
 

--- a/tf-common/2_config_ocp/variables.tf
+++ b/tf-common/2_config_ocp/variables.tf
@@ -85,6 +85,8 @@ variable "pull_secret" {}
 
 variable "release_image_override" {}
 variable "fips_compliant" {}
+variable "tech_preview" { default = "" }
+variable "os_image_stream" { default = "" }
 
 variable "private_network_mtu" {}
 

--- a/tf-powervc/ocp.tf
+++ b/tf-powervc/ocp.tf
@@ -144,6 +144,8 @@ module "config_ocp" {
   release_image_override     = var.release_image_override
   private_network_mtu        = var.private_network_mtu
   fips_compliant             = var.fips_compliant
+  tech_preview               = var.tech_preview
+  os_image_stream            = var.os_image_stream
   log_level                  = var.installer_log_level
   rhcos_pre_kernel_options   = var.rhcos_pre_kernel_options
   rhcos_kernel_options       = var.rhcos_kernel_options

--- a/tf-powervc/variables.tf
+++ b/tf-powervc/variables.tf
@@ -386,6 +386,18 @@ variable "fips_compliant" {
   default     = false
 }
 
+variable "tech_preview" {
+  type        = string
+  description = "Enable tech preview features (acts as boolean, intentionally a string). Valid values: 'true', 'false', '' (empty = disabled)"
+  default     = ""
+}
+
+variable "os_image_stream" {
+  type        = string
+  description = "Set OS image stream for RHEL-based RHCOS. Valid values: 'rhel-10', 'rhel-9', '' (empty = use default). Only applies when tech_preview is enabled."
+  default     = ""
+}
+
 variable "dns_forwarders" {
   default = "8.8.8.8"
 }

--- a/tf-powervs/modules/5_install/install.tf
+++ b/tf-powervs/modules/5_install/install.tf
@@ -123,6 +123,8 @@ locals {
     release_image_override   = var.enable_local_registry ? local.local_registry_ocp_image : var.release_image_override
     enable_local_registry    = var.enable_local_registry
     fips_compliant           = var.fips_compliant
+    tech_preview             = var.tech_preview
+    os_image_stream          = var.os_image_stream
     rhcos_pre_kernel_options = local.rhcos_pre_kernel_options
     rhcos_kernel_options     = var.rhcos_kernel_options
     node_labels              = merge(local.node_labels, var.node_labels)

--- a/tf-powervs/modules/5_install/templates/install_vars.yaml
+++ b/tf-powervs/modules/5_install/templates/install_vars.yaml
@@ -12,6 +12,8 @@ log_level: ${log_level}
 release_image_override: '${release_image_override}'
 enable_local_registry: ${enable_local_registry}
 fips_compliant: "${fips_compliant}"
+tech_preview: "${tech_preview}"
+os_image_stream: "${os_image_stream}"
 
 rhcos_pre_kernel_options: [%{ for opt in rhcos_pre_kernel_options ~}"${opt}",%{ endfor ~}]
 

--- a/tf-powervs/modules/5_install/variables.tf
+++ b/tf-powervs/modules/5_install/variables.tf
@@ -69,6 +69,8 @@ variable "openshift_install_tarball" {}
 variable "public_key" {}
 variable "pull_secret" {}
 variable "release_image_override" {}
+variable "tech_preview" { default = "" }
+variable "os_image_stream" { default = "" }
 
 variable "private_network_mtu" {}
 

--- a/tf-powervs/ocp.tf
+++ b/tf-powervs/ocp.tf
@@ -125,6 +125,8 @@ module "config_ocp" {
   cluster_domain                 = module.nodes.cluster_domain
   cluster_id                     = local.cluster_id
   fips_compliant                 = var.fips_compliant
+  tech_preview                   = var.tech_preview
+  os_image_stream                = var.os_image_stream
   dns_forwarders                 = var.dns_forwarders
   gateway_ip                     = module.bastion.gateway_ip
   cidr                           = module.bastion.cidr

--- a/tf-powervs/variables.tf
+++ b/tf-powervs/variables.tf
@@ -569,6 +569,18 @@ variable "fips_compliant" {
   default     = false
 }
 
+variable "tech_preview" {
+  type        = string
+  description = "Enable tech preview features (acts as boolean, intentionally a string). Valid values: 'true', 'false', '' (empty = disabled)"
+  default     = ""
+}
+
+variable "os_image_stream" {
+  type        = string
+  description = "Set OS image stream for RHEL-based RHCOS. Valid values: 'rhel-10', 'rhel-9', '' (empty = use default). Only applies when tech_preview is enabled."
+  default     = ""
+}
+
 
 ################################################################
 # Local registry variables ( used only for restricted network install )


### PR DESCRIPTION
fix: add techpreviewnoupgrade and osImageStream variables that are picked up by install-config.yaml